### PR TITLE
Switching to cookies dict to inject instead of CookieJar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-    -   id: black
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+- repo: https://github.com/psf/black
+  rev: 22.10.0
+  hooks:
+  - id: black
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.10.0
+  hooks:
+  - id: mypy
+    additional_dependencies: ['types-requests']

--- a/moocfi_cses.py
+++ b/moocfi_cses.py
@@ -8,6 +8,7 @@
 import argparse
 from dataclasses import dataclass, field
 from getpass import getpass
+import logging
 import json
 import urllib.parse
 from pathlib import Path
@@ -16,6 +17,12 @@ from typing import AnyStr
 import htmlement
 import requests
 
+
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 @dataclass
 class Session:
@@ -160,17 +167,31 @@ def read_config(configfile: str) -> dict:
 
 
 def read_cookie_file(cookiefile: str) -> dict[str, str]:
-    cookies = dict()
+    """
+    Reads cookies from a JSON formatted file.
+
+    Args:
+        cookiefile: str path to the file containing cookies.
+
+    Returns:
+        A dictionary of cookies.
+    """
     try:
         with open(cookiefile, "r") as f:
-            cookies = json.load(f)
-    except (FileNotFoundError, json.decoder.JSONDecodeError):
-        pass
-
-    return cookies
+            return json.load(f)
+    except (FileNotFoundError, json.decoder.JSONDecodeError) as e:
+        logging.debug(f"Error reading cookies from {cookiefile}: {e}")
+    return {}
 
 
 def write_cookie_file(cookiefile: str, cookies: dict[str, str]) -> None:
+    """
+    Writes cookies to a file in JSON format.
+
+    Args:
+        cookiefile: Path to the file for storing cookies.
+        cookies: A dictionary of cookies to write.
+    """
     with open(cookiefile, "w") as f:
         json.dump(cookies, f)
 
@@ -194,6 +215,7 @@ def parse_form(html: AnyStr, xpath: str = ".//form") -> dict[str, str]:
         form_data["_action"] = form_element.get("action")
         for form_input in form_element.iter("input"):
             form_data[form_input.get("name")] = form_input.get("value", "")
+            form_data[form_key] = form_value
 
     return form_data
 

--- a/moocfi_cses.py
+++ b/moocfi_cses.py
@@ -112,9 +112,9 @@ def parse_args(args: list | None = None) -> argparse.Namespace:
         ),
     )  # pyright: ignore[reportUnusedExpression]
     parser.add_argument(
-        "--state",
-        action="store_false",
-        help="Store cookies for faster access in the future",
+        "--no-state",
+        action="store_true",
+        help="Don't store cookies or cache (used for faster access on the future runs)",
     )
     subparsers = parser.add_subparsers(required=True)
 
@@ -279,7 +279,8 @@ def main() -> None:
 
     cookiefile = None
     cookies = dict()
-    if args.state:
+    print(args)
+    if not args.no_state:
         state_dir = Path("~/.local/state/moocfi_cses").expanduser()
         if not state_dir.exists():
             state_dir.mkdir(parents=True)
@@ -294,7 +295,7 @@ def main() -> None:
     )
     session.login()
 
-    if args.state and cookiefile:
+    if not args.no_state and cookiefile:
         cookies = requests.utils.dict_from_cookiejar(session.cookiejar)  # type: ignore[no-untyped-call]
         write_cookie_file(str(cookiefile), cookies)
 

--- a/stubs/htmlement.pyi
+++ b/stubs/htmlement.pyi
@@ -1,0 +1,58 @@
+from _typeshed import Incomplete
+from html.parser import HTMLParser
+import io
+from typing import Optional
+from xml.etree.ElementTree import Element
+
+__all__ = ["HTMLement", "fromstring", "fromstringlist", "parse"]
+
+def fromstring(
+    text: str | bytes,
+    tag: str = "",
+    attrs: Optional[dict[str, str]] = None,
+    encoding: Optional[str] = None,
+) -> Element: ...
+def fromstringlist(
+    sequence: str | bytes,
+    tag: str = "",
+    attrs: Optional[dict[str, str]] = None,
+    encoding: Optional[str] = None,
+) -> Element: ...
+def parse(
+    source: str | io.TextIOBase,
+    tag: str = "",
+    attrs: Optional[dict[str, str]] = None,
+    encoding: Optional[str] = None,
+) -> Element: ...
+
+class HTMLement:
+    encoding: str
+    def __init__(
+        self,
+        tag: str = "",
+        attrs: Optional[dict[str, str]] = None,
+        encoding: Optional[str] = None,
+    ) -> None: ...
+    def feed(self, data: str | bytes) -> None: ...
+    def close(self) -> Element: ...
+
+class ParseHTML(HTMLParser):
+    convert_charrefs: bool
+    enabled: bool
+    tag: str
+    attrs: dict[str, str]
+    def __init__(
+        self, tag: str = "", attrs: Optional[dict[str, str]] = None
+    ) -> None: ...
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None: ...
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None: ...
+    def handle_endtag(self, tag: str) -> None: ...
+    def handle_data(self, data: str) -> None: ...
+    def handle_entityref(self, name: str) -> None: ...
+    def handle_charref(self, name: str) -> None: ...
+    def handle_comment(self, data: str) -> None: ...
+    def close(self) -> None: ...

--- a/stubs/htmlement.pyi
+++ b/stubs/htmlement.pyi
@@ -1,4 +1,3 @@
-from _typeshed import Incomplete
 from html.parser import HTMLParser
 import io
 from typing import Optional

--- a/tests/test_moocfi_cses.py
+++ b/tests/test_moocfi_cses.py
@@ -3,12 +3,12 @@ import pytest
 import requests_mock
 
 
-def test_parse_args_missing_args():
+def test_parse_args_missing_args() -> None:
     with pytest.raises(SystemExit):
         moocfi_cses.parse_args()
 
 
-def test_parse_args_command():
+def test_parse_args_command() -> None:
     args = moocfi_cses.parse_args(["list"])
     assert args.cmd == "list"
 
@@ -24,16 +24,16 @@ class TestFindLink:
     invalid_xpath = './/a[@class="somethingelse"]'
     valid_return = {"href": "somelink", "text": "sometext"}
 
-    def test_find_link_success(self):
+    def test_find_link_success(self) -> None:
         assert (
             moocfi_cses.find_link(self.valid_html, self.valid_xpath)
             == self.valid_return
         )
 
-    def test_find_link_bad_xpath(self):
+    def test_find_link_bad_xpath(self) -> None:
         assert moocfi_cses.find_link(self.valid_html, self.invalid_xpath) == {}
 
-    def test_find_link_bad_html(self):
+    def test_find_link_bad_html(self) -> None:
         assert moocfi_cses.find_link(self.invalid_html, self.valid_xpath) == {}
 
 
@@ -52,7 +52,7 @@ class TestParseForm:
 # TODO: verify these mocked tests are actually accurate
 # TODO: add tests for unreachable and failing endpoints, 4xx, 5xx, etc
 @pytest.fixture
-def mock_session():
+def mock_session() -> moocfi_cses.Session:
     return moocfi_cses.Session(
         username="test_user@test.com",
         password="test_password",
@@ -60,7 +60,7 @@ def mock_session():
     )
 
 
-def test_login_successful(mock_session):
+def test_login_successful(mock_session: moocfi_cses.Session) -> None:
     # Mocking the HTTP response for successful login
     with requests_mock.Mocker() as m:
         m.get(
@@ -71,7 +71,7 @@ def test_login_successful(mock_session):
         assert mock_session.is_logged_in
 
 
-def test_login_failed(mock_session):
+def test_login_failed(mock_session: moocfi_cses.Session) -> None:
     # Mocking the HTTP response for failed login
     with requests_mock.Mocker() as m:
         m.get(
@@ -85,17 +85,17 @@ def test_login_failed(mock_session):
 
 
 # TODO: functions that use user input or read or write files
-def test_create_config():
+def test_create_config() -> None:
     ...
 
 
-def test_write_config():
+def test_write_config() -> None:
     ...
 
 
-def test_read_config():
+def test_read_config() -> None:
     ...
 
 
-def test_get_cookiejar():
+def test_get_cookiejar() -> None:
     ...


### PR DESCRIPTION
This should make some of the code easier to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **Refactor**
    - Enhanced cookie handling to utilize a dictionary format instead of `http.cookiejar`.
    - Improved command-line options with the addition of `--state` for managing cookies.

- **New Features**
    - Implemented cookie reading and writing functionalities using a dictionary format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->